### PR TITLE
Refactor unit tests

### DIFF
--- a/tests/test_ace.py
+++ b/tests/test_ace.py
@@ -1,38 +1,12 @@
-from io import StringIO
-
 import pytest
 import tomli
 from ace import __version__
-from ace.inputs import CommandLineInput
 from ace.outputs import CommandLineOutput
 
 
 def test_version():
     with open("pyproject.toml", "rb") as f:
         assert __version__ == tomli.load(f)["tool"]["poetry"]["version"]
-
-
-@pytest.mark.parametrize(
-    "prompt,expected",
-    [
-        ("Enter your name", "Enter your name "),
-        ("Enter your age:", "Enter your age: "),
-        ("Email>", "Email> "),
-        ("", ""),
-        ("  ", ""),
-        (None, ""),
-        ("1.  ", "1. "),
-        ("Select menu number: ", "Select menu number: "),
-    ],
-)
-def test_get_command_line_input(prompt, expected, monkeypatch, capsys):
-    text_input = CommandLineInput(prompt)
-    monkeypatch.setattr("sys.stdin", StringIO("ABC"))
-
-    output = text_input.get()
-
-    assert capsys.readouterr().out == expected
-    assert isinstance(output, str), "Should return a string"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ace.py
+++ b/tests/test_ace.py
@@ -1,27 +1,7 @@
-import pytest
 import tomli
 from ace import __version__
-from ace.outputs import CommandLineOutput
 
 
 def test_version():
     with open("pyproject.toml", "rb") as f:
         assert __version__ == tomli.load(f)["tool"]["poetry"]["version"]
-
-
-@pytest.mark.parametrize(
-    "prefix,message,expected",
-    [
-        ("ACE:", "Hello", "ACE: Hello\n"),
-        ("", "Hello", "Hello\n"),
-        (None, "Hello", "Hello\n"),
-        ("", "", "\n"),
-        (">", "Hello world!", "> Hello world!\n"),
-        ("  ", "Spaces are trimmed", "Spaces are trimmed\n"),
-    ],
-)
-def test_broadcast_command_line_output(prefix, message, expected, capsys):
-    text_output = CommandLineOutput(prefix)
-    text_output.broadcast(message)
-
-    assert capsys.readouterr().out == expected

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,0 +1,27 @@
+from io import StringIO
+
+import pytest
+from ace.inputs import CommandLineInput
+
+
+@pytest.mark.parametrize(
+    "prompt,expected",
+    [
+        ("Enter your name", "Enter your name "),
+        ("Enter your age:", "Enter your age: "),
+        ("Email>", "Email> "),
+        ("", ""),
+        ("  ", ""),
+        (None, ""),
+        ("1.  ", "1. "),
+        ("Select menu number: ", "Select menu number: "),
+    ],
+)
+def test_get_command_line_input(prompt, expected, monkeypatch, capsys):
+    text_input = CommandLineInput(prompt)
+    monkeypatch.setattr("sys.stdin", StringIO("ABC"))
+
+    output = text_input.get()
+
+    assert capsys.readouterr().out == expected
+    assert isinstance(output, str), "Should return a string"

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -4,24 +4,61 @@ import pytest
 from ace.inputs import CommandLineInput
 
 
-@pytest.mark.parametrize(
-    "prompt,expected",
-    [
-        ("Enter your name", "Enter your name "),
-        ("Enter your age:", "Enter your age: "),
-        ("Email>", "Email> "),
-        ("", ""),
-        ("  ", ""),
-        (None, ""),
-        ("1.  ", "1. "),
-        ("Select menu number: ", "Select menu number: "),
-    ],
-)
-def test_get_command_line_input(prompt, expected, monkeypatch, capsys):
-    text_input = CommandLineInput(prompt)
-    monkeypatch.setattr("sys.stdin", StringIO("ABC"))
+class TestCommandLineInputs:
+    @pytest.mark.parametrize(
+        "prompt,expected",
+        [
+            ("", ""),
+            ("  ", ""),
+            (None, ""),
+        ],
+    )
+    def test_get_command_line_input_no_prompt(
+        self, prompt, expected, monkeypatch, capsys
+    ):
+        text_input = CommandLineInput(prompt)
+        monkeypatch.setattr("sys.stdin", StringIO("ABC"))
 
-    output = text_input.get()
+        output = text_input.get()
 
-    assert capsys.readouterr().out == expected
-    assert isinstance(output, str), "Should return a string"
+        assert capsys.readouterr().out == expected
+        assert isinstance(output, str), "Should return a string"
+
+    @pytest.mark.parametrize(
+        "prompt,expected",
+        [
+            ("A", "A "),
+            ("Enter age ", "Enter age "),
+            ("mobile number     ", "mobile number "),
+        ],
+    )
+    def test_get_command_line_input_no_special_character(
+        self, prompt, expected, monkeypatch, capsys
+    ):
+        text_input = CommandLineInput(prompt)
+        monkeypatch.setattr("sys.stdin", StringIO("ABC"))
+
+        output = text_input.get()
+
+        assert capsys.readouterr().out == expected
+        assert isinstance(output, str), "Should return a string"
+
+    @pytest.mark.parametrize(
+        "prompt,expected",
+        [
+            ("1.  ", "1. "),
+            ("Select menu number: ", "Select menu number: "),
+            ("What is your name?", "What is your name? "),
+            ("Email>", "Email> "),
+        ],
+    )
+    def test_get_command_line_input_special_character(
+        self, prompt, expected, monkeypatch, capsys
+    ):
+        text_input = CommandLineInput(prompt)
+        monkeypatch.setattr("sys.stdin", StringIO("ABC"))
+
+        output = text_input.get()
+
+        assert capsys.readouterr().out == expected
+        assert isinstance(output, str), "Should return a string"

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,0 +1,20 @@
+import pytest
+from ace.outputs import CommandLineOutput
+
+
+@pytest.mark.parametrize(
+    "prefix,message,expected",
+    [
+        ("ACE:", "Hello", "ACE: Hello\n"),
+        ("", "Hello", "Hello\n"),
+        (None, "Hello", "Hello\n"),
+        ("", "", "\n"),
+        (">", "Hello world!", "> Hello world!\n"),
+        ("  ", "Spaces are trimmed", "Spaces are trimmed\n"),
+    ],
+)
+def test_broadcast_command_line_output(prefix, message, expected, capsys):
+    text_output = CommandLineOutput(prefix)
+    text_output.broadcast(message)
+
+    assert capsys.readouterr().out == expected

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -2,19 +2,52 @@ import pytest
 from ace.outputs import CommandLineOutput
 
 
-@pytest.mark.parametrize(
-    "prefix,message,expected",
-    [
-        ("ACE:", "Hello", "ACE: Hello\n"),
-        ("", "Hello", "Hello\n"),
-        (None, "Hello", "Hello\n"),
-        ("", "", "\n"),
-        (">", "Hello world!", "> Hello world!\n"),
-        ("  ", "Spaces are trimmed", "Spaces are trimmed\n"),
-    ],
-)
-def test_broadcast_command_line_output(prefix, message, expected, capsys):
-    text_output = CommandLineOutput(prefix)
-    text_output.broadcast(message)
+class TestCommandLineOutput:
+    @pytest.mark.parametrize(
+        "prefix,message,expected",
+        [
+            ("", "Hello", "Hello\n"),
+            (None, "Hello", "Hello\n"),
+            ("", "", "\n"),
+            ("  ", "Spaces are trimmed", "Spaces are trimmed\n"),
+        ],
+    )
+    def test_broadcast_command_line_output_no_prefix(
+        self, prefix, message, expected, capsys
+    ):
+        text_output = CommandLineOutput(prefix)
+        text_output.broadcast(message)
 
-    assert capsys.readouterr().out == expected
+        assert capsys.readouterr().out == expected
+
+    @pytest.mark.parametrize(
+        "prefix,message,expected",
+        [
+            ("1", "Hello", "1 Hello\n"),
+            ("2    ", "I'm trimmed", "2 I'm trimmed\n"),
+            ("Hello ", "World", "Hello World\n"),
+        ],
+    )
+    def test_broadcast_command_line_output_no_special_character(
+        self, prefix, message, expected, capsys
+    ):
+        text_output = CommandLineOutput(prefix)
+        text_output.broadcast(message)
+
+        assert capsys.readouterr().out == expected
+
+    @pytest.mark.parametrize(
+        "prefix,message,expected",
+        [
+            ("ACE:", "Hello", "ACE: Hello\n"),
+            (">", "Hello world!", "> Hello world!\n"),
+            ("-     ", "Spam", "- Spam\n"),
+        ],
+    )
+    def test_broadcast_command_line_output_special_character(
+        self, prefix, message, expected, capsys
+    ):
+        text_output = CommandLineOutput(prefix)
+        text_output.broadcast(message)
+
+        assert capsys.readouterr().out == expected


### PR DESCRIPTION
### Changes
- Move unit tests for input functionality to test_inputs.py
- Split the parametrised tests for inputs in test_inputs.py
- Move unit tests for output functionality to test_outputs.py
- Split the parametrised tests for outputs in test_outputs.py