### PR TITLE
Add colour to command line inputs and outputs

### DIFF
--- a/ace/utils.py
+++ b/ace/utils.py
@@ -1,0 +1,14 @@
+import re
+
+
+class TextProcessor:
+    """
+    Class for storing helper functions related to processing
+    and formatting text.
+    """
+
+    def remove_ansi_escape(self, text: str) -> str:
+        """
+        Remove ANSI escape sequences from a string.
+        """
+        return re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", text)

--- a/main.py
+++ b/main.py
@@ -1,16 +1,21 @@
 import sys
+
+from colorama import Fore, init as colorama_init
+
 from ace import intents
 from ace.inputs import CommandLineInput
 from ace.net import IntentModel
 from ace.outputs import CommandLineOutput
+
+colorama_init(autoreset=True)
 
 
 def main() -> None:
     """
     The entry point of the program.
     """
-    user_input = CommandLineInput("You:")
-    ace_output = CommandLineOutput("ACE:")
+    user_input = CommandLineInput(f"{Fore.CYAN}You:")
+    ace_output = CommandLineOutput(f"{Fore.YELLOW}ACE:")
 
     model = IntentModel()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -55,9 +55,9 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -245,7 +245,7 @@ python-versions = ">=3.6"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "218e0b1f9c03b1872f965f8398b745deebf1ed1ae6f1fc17e245df7704b6c0eb"
+content-hash = "09673cb8ef0d69c59a9265ad19ea3d242c71286865c2e1151db8a18b027634aa"
 
 [metadata.files]
 atomicwrites = [
@@ -286,8 +286,8 @@ click = [
     {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 coverage = [
     {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Illy Shaieb <shaiebilly+ace@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
+colorama = "^0.4.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -2,6 +2,9 @@ from io import StringIO
 
 import pytest
 from ace.inputs import CommandLineInput
+from ace.utils import TextProcessor
+
+text_processor = TextProcessor()
 
 
 class TestCommandLineInputs:
@@ -21,7 +24,7 @@ class TestCommandLineInputs:
 
         output = text_input.get()
 
-        assert capsys.readouterr().out == expected
+        assert text_processor.remove_ansi_escape(capsys.readouterr().out) == expected
         assert isinstance(output, str), "Should return a string"
 
     @pytest.mark.parametrize(
@@ -40,7 +43,7 @@ class TestCommandLineInputs:
 
         output = text_input.get()
 
-        assert capsys.readouterr().out == expected
+        assert text_processor.remove_ansi_escape(capsys.readouterr().out) == expected
         assert isinstance(output, str), "Should return a string"
 
     @pytest.mark.parametrize(
@@ -60,5 +63,5 @@ class TestCommandLineInputs:
 
         output = text_input.get()
 
-        assert capsys.readouterr().out == expected
+        assert text_processor.remove_ansi_escape(capsys.readouterr().out) == expected
         assert isinstance(output, str), "Should return a string"

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,5 +1,8 @@
 import pytest
 from ace.outputs import CommandLineOutput
+from ace.utils import TextProcessor
+
+text_processor = TextProcessor()
 
 
 class TestCommandLineOutput:
@@ -18,7 +21,7 @@ class TestCommandLineOutput:
         text_output = CommandLineOutput(prefix)
         text_output.broadcast(message)
 
-        assert capsys.readouterr().out == expected
+        assert text_processor.remove_ansi_escape(capsys.readouterr().out) == expected
 
     @pytest.mark.parametrize(
         "prefix,message,expected",
@@ -34,7 +37,7 @@ class TestCommandLineOutput:
         text_output = CommandLineOutput(prefix)
         text_output.broadcast(message)
 
-        assert capsys.readouterr().out == expected
+        assert text_processor.remove_ansi_escape(capsys.readouterr().out) == expected
 
     @pytest.mark.parametrize(
         "prefix,message,expected",
@@ -50,4 +53,4 @@ class TestCommandLineOutput:
         text_output = CommandLineOutput(prefix)
         text_output.broadcast(message)
 
-        assert capsys.readouterr().out == expected
+        assert text_processor.remove_ansi_escape(capsys.readouterr().out) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from ace import utils
+
+
+class TestTextProcessor:
+    processor = utils.TextProcessor()
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("\u001b[30m", ""),
+            ("\u001b[30m\u001b[30m", ""),
+            ("\u001b[30mHello", "Hello"),
+            ("\u001b[36mExample Text", "Example Text"),
+            ("\u001b[4m Another example\u001b[0m", " Another example"),
+            ("\u001b[45;1mTest with a number: 123", "Test with a number: 123"),
+        ],
+    )
+    def test_remove_ansi_escape(self, text, expected):
+        assert self.processor.remove_ansi_escape(text) == expected


### PR DESCRIPTION
### Changes
- Install colorama using poetry
- Add TextProcessor class in utils.py
- Implement remove_ansi_escape in test_inputs.py and test_outputs.py
- Add colour to inputs and outputs in main.py