### PR TITLE
Add weather intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,23 @@ $ poetry run python main.py
 ```
 
 ## Features
-| | Intent | Description | Example |
-| --- | --- | --- | --- |
-| :wave: | greeting | respond with a greeting message | hello |
-| :runner: | goodbye | respond with a goodbye message and then exit| goodbye |
-| :computer: | open_app | open the specified application* | open excel |
-| :computer: | close_app | close the specified application* | close notepad |
+| | Intent | Description | Example | Notes |
+| --- | --- | --- | --- | --- |
+| :wave: | greeting | respond with a greeting message | hello | |
+| :runner: | goodbye | respond with a goodbye message and then exit| goodbye | |
+| :computer: | open_app | open the specified application | open excel | **Only available on windows** |
+| :computer: | close_app | close the specified application | close notepad | **Only available on windows** |
+| :partly_sunny: | current_weather | get the current weather for a location | current weather in London | **See [Weather](#weather) section for setup details**|
 
-*Note: This intent is currently only available on Windows.
+## Weather
+To set up the weather intent, you must set the following environment variables:
+| Variable | Example | Description |
+| --- | --- | --- |
+| `ACE_HOME` | London | The default location for the weather intent, if no location is specified. |
+| `ACE_WEATHER_KEY` | 822fc8446f5adc72ac8c766a871329a8 | The API key for the [OpenWeatherMap API](https://openweathermap.org/api) |
+
+For Unix/Linux follow this link to set the environment variables:
+- https://www.tutorialspoint.com/unix/unix-environment.html
+
+For Windows follow this link to set the environment variables:
+- https://www.computerhope.com/issues/ch000549.html

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ $ poetry run python main.py
 | :computer: | open_app | open the specified application | open excel | **Only available on windows** |
 | :computer: | close_app | close the specified application | close notepad | **Only available on windows** |
 | :partly_sunny: | current_weather | get the current weather for a location | current weather in London | **See [Weather](#weather) section for setup details**|
+| :partly_sunny: | tomorrow_weather | get tomorrow's weather for a location | tomorrow's weather in London | **See [Weather](#weather) section for setup details**|
 
 ## Weather
 To set up the weather intent, you must set the following environment variables:

--- a/ace/apis.py
+++ b/ace/apis.py
@@ -2,7 +2,7 @@ import os
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime as dt, timedelta
-from pprint import pprint
+
 from typing import Union
 
 import requests

--- a/ace/apis.py
+++ b/ace/apis.py
@@ -1,0 +1,67 @@
+import os
+from dataclasses import dataclass, field
+from typing import Union
+
+import requests
+
+
+@dataclass
+class WeatherAPI:
+    """
+    A class to interface with any weather API.
+    """
+
+    _base_urls: dict[str, str] = field(
+        default_factory=lambda: {
+            "current": "https://api.openweathermap.org/data/2.5/weather?"
+        }
+    )
+
+    def get_current_weather(
+        self, location: str = "", units: str = "metric"
+    ) -> Union[dict, None]:
+        """
+        Returns a dictionary containing the current weather for a location,
+        or None if there was an error.
+
+        If no location is provided, the location will be determined by the
+        location set up in the ACE_HOME environment variable.
+        """
+        location = location or os.environ["ACE_HOME"]
+
+        if response := self._get_response(location, units, "current"):
+
+            if response["cod"] == 200:
+                return {
+                    "location": location.title(),
+                    "condition": response["weather"][0]["description"],
+                    "temp": {
+                        "units": "C" if units == "metric" else "F",
+                        "current": response["main"]["temp"],
+                    },
+                    "code": str(response["cod"]),
+                }
+
+            return {"code": str(response["cod"]), "message": response["message"]}
+
+        return None
+
+    def _get_response(
+        self, location: str, units: str, tag: str
+    ) -> dict:  # pragma: no cover
+        """
+        Helper function to get the response from the API.
+
+        Return None if no connection.
+        """
+        try:
+
+            base_url = self._base_urls.get(tag, "current")
+            api_key: str = f"{os.environ['ACE_WEATHER_KEY']}"
+            url = f"{base_url}q={location}&appid={api_key}&units={units}"
+
+            return requests.get(url).json()
+
+        except requests.exceptions.ConnectionError:
+
+            return None

--- a/ace/intents.py
+++ b/ace/intents.py
@@ -139,6 +139,46 @@ def current_weather(text: str) -> str:
     return "Sorry, I couldn't get the weather for you. Check your connection and try again."
 
 
+@_register(requires_text=True)
+def tomorrow_weather(text: str) -> str:
+    stop_words = [
+        "tomorrow's weather",
+        "tomorrow weather in",
+        "get tomorrow weather",
+        "tomorrow weather conditions",
+        "tomorrow weather",
+        "get weather tomorrow",
+        "weather tomorrow",
+        " tomorrow ",
+        " tomorrow",
+        "tomorrow ",
+        " in ",
+        " in",
+        "in ",
+    ]
+
+    if response := weather_api.get_tomorrow_weather(
+        re.sub("|".join(stop_words), "", text, flags=re.IGNORECASE).replace(" ", "")
+    ):
+
+        if response["code"] == "200":
+
+            unit = f"{DEGREES}{response['temp']['units']}"
+
+            return f"The weather tomorrow in {response['location']} will be {response['temp']['value']}{unit} and {response['condition']}."
+
+        elif response["code"] == "401":
+            return "The configured weather API key is invalid. Please check the 'ACE_WEATHER_KEY' environment variable."
+
+        elif response["code"] == "404":
+            return "Couldn't find that location. Check the spelling and try again."
+
+        elif response["code"] == "429":
+            return "The configured weather API key has been used too many times. Please wait and try again."
+
+    return "Sorry, I couldn't get the weather for you. Check your connection and try again."
+
+
 if __name__ == "__main__":  # pragma: no cover
     from pprint import pprint
 

--- a/ace/net.py
+++ b/ace/net.py
@@ -43,4 +43,10 @@ class IntentModel:
             "goodbye": ["goodbye", "good bye", "bye"],
             "open_app": ["open", "start"],
             "close_app": ["close", "stop"],
+            "current_weather": [
+                "current weather",
+                "weather in",
+                "get weather in",
+                "get current weather",
+            ],
         }

--- a/ace/net.py
+++ b/ace/net.py
@@ -49,4 +49,11 @@ class IntentModel:
                 "get weather in",
                 "get current weather",
             ],
+            "tomorrow_weather": [
+                "tomorrow's weather",
+                "tomorrow weather",
+                "weather tomorrow",
+                "get weather tomorrow",
+                "what will tomorrow's weather",
+            ],
         }

--- a/poetry.lock
+++ b/poetry.lock
@@ -43,6 +43,25 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "certifi"
+version = "2022.6.15"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.1.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "click"
 version = "8.0.4"
 description = "Composable command line interface toolkit"
@@ -87,6 +106,14 @@ python-versions = ">=3.6"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "iniconfig"
@@ -227,6 +254,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "requests"
+version = "2.28.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -242,10 +287,23 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[[package]]
+name = "urllib3"
+version = "1.26.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "09673cb8ef0d69c59a9265ad19ea3d242c71286865c2e1151db8a18b027634aa"
+content-hash = "685f6a86e6b98e7d533f96a3c70eadfa0c62cc98c41f673b5ee4eba17ef204c2"
 
 [metadata.files]
 atomicwrites = [
@@ -280,6 +338,14 @@ black = [
     {file = "black-22.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321"},
     {file = "black-22.1.0-py3-none-any.whl", hash = "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d"},
     {file = "black-22.1.0.tar.gz", hash = "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5"},
+]
+certifi = [
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
+    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
 ]
 click = [
     {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
@@ -336,6 +402,10 @@ flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -388,6 +458,10 @@ pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
+requests = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
@@ -395,4 +469,8 @@ tomli = [
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -43,6 +43,14 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cachetools"
+version = "5.2.0"
+description = "Extensible memoizing collections and decorators"
+category = "main"
+optional = false
+python-versions = "~=3.7"
+
+[[package]]
 name = "certifi"
 version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -82,7 +90,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.2"
+version = "6.4.4"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -333,7 +341,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "735b1271b960c2559e8d3febd57a0709fd15493f1a50fed4d5ad0418e2331d88"
+content-hash = "6cde03dcfcf6310e9d9fa5a358ae142171d5c8326e87b478baaf7ecf257954f9"
 
 [metadata.files]
 atomicwrites = [
@@ -368,6 +376,10 @@ black = [
     {file = "black-22.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321"},
     {file = "black-22.1.0-py3-none-any.whl", hash = "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d"},
     {file = "black-22.1.0.tar.gz", hash = "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5"},
+]
+cachetools = [
+    {file = "cachetools-5.2.0-py3-none-any.whl", hash = "sha256:f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db"},
+    {file = "cachetools-5.2.0.tar.gz", hash = "sha256:6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757"},
 ]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -82,7 +82,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.1"
+version = "6.4.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -106,6 +106,17 @@ python-versions = ">=3.6"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "freezegun"
+version = "1.2.1"
+description = "Let your Python tests travel through time"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
 
 [[package]]
 name = "idna"
@@ -254,6 +265,17 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
@@ -270,6 +292,14 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
@@ -303,7 +333,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "685f6a86e6b98e7d533f96a3c70eadfa0c62cc98c41f673b5ee4eba17ef204c2"
+content-hash = "735b1271b960c2559e8d3febd57a0709fd15493f1a50fed4d5ad0418e2331d88"
 
 [metadata.files]
 atomicwrites = [
@@ -355,53 +385,12 @@ colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
-coverage = [
-    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
-    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
-    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
-    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
-    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
-    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
-    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
-    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
-    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
-    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
-    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
-    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
-    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
-]
+coverage = []
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
+freezegun = []
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
@@ -458,9 +447,17 @@ pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Illy Shaieb <shaiebilly+ace@gmail.com>"]
 python = "^3.9"
 colorama = "^0.4.5"
 requests = "^2.28.1"
+freezegun = "^1.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.9"
 colorama = "^0.4.5"
 requests = "^2.28.1"
 freezegun = "^1.2.1"
+cachetools = "^5.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Illy Shaieb <shaiebilly+ace@gmail.com>"]
 [tool.poetry.dependencies]
 python = "^3.9"
 colorama = "^0.4.5"
+requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"

--- a/tests/data/weather/current_weather.json
+++ b/tests/data/weather/current_weather.json
@@ -1,0 +1,62 @@
+{
+    "SUCCESS": {
+        "coord": {
+            "lon": -0.4541,
+            "lat": 51.0192
+        },
+        "weather": [
+            {
+                "id": 801,
+                "main": "Clouds",
+                "description": "few clouds",
+                "icon": "02n"
+            }
+        ],
+        "base": "stations",
+        "main": {
+            "temp": 14.19,
+            "feels_like": 13.75,
+            "temp_min": 12.25,
+            "temp_max": 15.83,
+            "pressure": 1023,
+            "humidity": 80,
+            "sea_level": 1023,
+            "grnd_level": 1020
+        },
+        "visibility": 10000,
+        "wind": {
+            "speed": 2.84,
+            "deg": 299,
+            "gust": 5.82
+        },
+        "clouds": {
+            "all": 24
+        },
+        "dt": 1656975896,
+        "sys": {
+            "type": 2,
+            "id": 2005076,
+            "country": "GB",
+            "sunrise": 1656993258,
+            "sunset": 1657052284
+        },
+        "timezone": 3600,
+        "id": 2655662,
+        "name": "Billingshurst",
+        "cod": 200
+    },
+    "FAILURE": {
+        "404": {
+            "cod": 404,
+            "message": "city not found"
+        },
+        "401": {
+            "cod": 401,
+            "message": "invalid API key"
+        },
+        "429": {
+            "cod": 429,
+            "message": "too many requests"
+        }
+    }
+}

--- a/tests/data/weather/tomorrow_weather.json
+++ b/tests/data/weather/tomorrow_weather.json
@@ -1,0 +1,1476 @@
+{
+    "SUCCESS": {
+        "cod": "200",
+        "message": 0,
+        "cnt": 40,
+        "list": [
+            {
+                "dt": 1657702800,
+                "main": {
+                    "temp": 22.66,
+                    "feels_like": 22.76,
+                    "temp_min": 22.66,
+                    "temp_max": 24.89,
+                    "pressure": 1022,
+                    "sea_level": 1022,
+                    "grnd_level": 1018,
+                    "humidity": 68,
+                    "temp_kf": -2.23
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 92
+                },
+                "wind": {
+                    "speed": 3.5,
+                    "deg": 341,
+                    "gust": 3.36
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-13 09:00:00"
+            },
+            {
+                "dt": 1657713600,
+                "main": {
+                    "temp": 25.72,
+                    "feels_like": 25.68,
+                    "temp_min": 25.72,
+                    "temp_max": 27.81,
+                    "pressure": 1021,
+                    "sea_level": 1021,
+                    "grnd_level": 1018,
+                    "humidity": 51,
+                    "temp_kf": -2.09
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 89
+                },
+                "wind": {
+                    "speed": 3.23,
+                    "deg": 328,
+                    "gust": 4.14
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-13 12:00:00"
+            },
+            {
+                "dt": 1657724400,
+                "main": {
+                    "temp": 29.54,
+                    "feels_like": 28.47,
+                    "temp_min": 29.54,
+                    "temp_max": 29.54,
+                    "pressure": 1020,
+                    "sea_level": 1020,
+                    "grnd_level": 1017,
+                    "humidity": 32,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 99
+                },
+                "wind": {
+                    "speed": 1.35,
+                    "deg": 264,
+                    "gust": 3.13
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-13 15:00:00"
+            },
+            {
+                "dt": 1657735200,
+                "main": {
+                    "temp": 27.11,
+                    "feels_like": 26.79,
+                    "temp_min": 27.11,
+                    "temp_max": 27.11,
+                    "pressure": 1020,
+                    "sea_level": 1020,
+                    "grnd_level": 1017,
+                    "humidity": 37,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 99
+                },
+                "wind": {
+                    "speed": 1.85,
+                    "deg": 352,
+                    "gust": 3.64
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-13 18:00:00"
+            },
+            {
+                "dt": 1657746000,
+                "main": {
+                    "temp": 18.84,
+                    "feels_like": 18.56,
+                    "temp_min": 18.84,
+                    "temp_max": 18.84,
+                    "pressure": 1021,
+                    "sea_level": 1021,
+                    "grnd_level": 1017,
+                    "humidity": 68,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 100
+                },
+                "wind": {
+                    "speed": 3.65,
+                    "deg": 48,
+                    "gust": 7.37
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-13 21:00:00"
+            },
+            {
+                "dt": 1657756800,
+                "main": {
+                    "temp": 16.47,
+                    "feels_like": 16.31,
+                    "temp_min": 16.47,
+                    "temp_max": 16.47,
+                    "pressure": 1021,
+                    "sea_level": 1021,
+                    "grnd_level": 1018,
+                    "humidity": 82,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 100
+                },
+                "wind": {
+                    "speed": 2.54,
+                    "deg": 40,
+                    "gust": 5.18
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-14 00:00:00"
+            },
+            {
+                "dt": 1657767600,
+                "main": {
+                    "temp": 14.23,
+                    "feels_like": 14.11,
+                    "temp_min": 14.23,
+                    "temp_max": 14.23,
+                    "pressure": 1021,
+                    "sea_level": 1021,
+                    "grnd_level": 1018,
+                    "humidity": 92,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 100
+                },
+                "wind": {
+                    "speed": 2.89,
+                    "deg": 3,
+                    "gust": 4.92
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-14 03:00:00"
+            },
+            {
+                "dt": 1657778400,
+                "main": {
+                    "temp": 16.23,
+                    "feels_like": 15.42,
+                    "temp_min": 16.23,
+                    "temp_max": 16.23,
+                    "pressure": 1022,
+                    "sea_level": 1022,
+                    "grnd_level": 1019,
+                    "humidity": 58,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 52
+                },
+                "wind": {
+                    "speed": 5.14,
+                    "deg": 360,
+                    "gust": 9.13
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-14 06:00:00"
+            },
+            {
+                "dt": 1657789200,
+                "main": {
+                    "temp": 21.59,
+                    "feels_like": 20.77,
+                    "temp_min": 21.59,
+                    "temp_max": 21.59,
+                    "pressure": 1022,
+                    "sea_level": 1022,
+                    "grnd_level": 1019,
+                    "humidity": 37,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 801,
+                        "main": "Clouds",
+                        "description": "few clouds",
+                        "icon": "02d"
+                    }
+                ],
+                "clouds": {
+                    "all": 23
+                },
+                "wind": {
+                    "speed": 5.69,
+                    "deg": 349,
+                    "gust": 6.48
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-14 09:00:00"
+            },
+            {
+                "dt": 1657800000,
+                "main": {
+                    "temp": 24.93,
+                    "feels_like": 24.29,
+                    "temp_min": 24.93,
+                    "temp_max": 24.93,
+                    "pressure": 1022,
+                    "sea_level": 1022,
+                    "grnd_level": 1019,
+                    "humidity": 31,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 28
+                },
+                "wind": {
+                    "speed": 5.44,
+                    "deg": 339,
+                    "gust": 6.16
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-14 12:00:00"
+            },
+            {
+                "dt": 1657810800,
+                "main": {
+                    "temp": 25.45,
+                    "feels_like": 24.78,
+                    "temp_min": 25.45,
+                    "temp_max": 25.45,
+                    "pressure": 1022,
+                    "sea_level": 1022,
+                    "grnd_level": 1019,
+                    "humidity": 28,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 48
+                },
+                "wind": {
+                    "speed": 6.19,
+                    "deg": 335,
+                    "gust": 6.46
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-14 15:00:00"
+            },
+            {
+                "dt": 1657821600,
+                "main": {
+                    "temp": 24.06,
+                    "feels_like": 23.33,
+                    "temp_min": 24.06,
+                    "temp_max": 24.06,
+                    "pressure": 1022,
+                    "sea_level": 1022,
+                    "grnd_level": 1019,
+                    "humidity": 31,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 64
+                },
+                "wind": {
+                    "speed": 5.82,
+                    "deg": 357,
+                    "gust": 5.25
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-14 18:00:00"
+            },
+            {
+                "dt": 1657832400,
+                "main": {
+                    "temp": 16.96,
+                    "feels_like": 15.99,
+                    "temp_min": 16.96,
+                    "temp_max": 16.96,
+                    "pressure": 1024,
+                    "sea_level": 1024,
+                    "grnd_level": 1021,
+                    "humidity": 49,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03n"
+                    }
+                ],
+                "clouds": {
+                    "all": 31
+                },
+                "wind": {
+                    "speed": 4.59,
+                    "deg": 0,
+                    "gust": 10.03
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-14 21:00:00"
+            },
+            {
+                "dt": 1657843200,
+                "main": {
+                    "temp": 12.85,
+                    "feels_like": 11.86,
+                    "temp_min": 12.85,
+                    "temp_max": 12.85,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 64,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03n"
+                    }
+                ],
+                "clouds": {
+                    "all": 27
+                },
+                "wind": {
+                    "speed": 2.29,
+                    "deg": 336,
+                    "gust": 2.33
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-15 00:00:00"
+            },
+            {
+                "dt": 1657854000,
+                "main": {
+                    "temp": 11.34,
+                    "feels_like": 10.46,
+                    "temp_min": 11.34,
+                    "temp_max": 11.34,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 74,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 70
+                },
+                "wind": {
+                    "speed": 2.4,
+                    "deg": 342,
+                    "gust": 2.45
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-15 03:00:00"
+            },
+            {
+                "dt": 1657864800,
+                "main": {
+                    "temp": 14.26,
+                    "feels_like": 13.41,
+                    "temp_min": 14.26,
+                    "temp_max": 14.26,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 64,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 83
+                },
+                "wind": {
+                    "speed": 1.92,
+                    "deg": 344,
+                    "gust": 2.98
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-15 06:00:00"
+            },
+            {
+                "dt": 1657875600,
+                "main": {
+                    "temp": 20.59,
+                    "feels_like": 19.72,
+                    "temp_min": 20.59,
+                    "temp_max": 20.59,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1021,
+                    "humidity": 39,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 56
+                },
+                "wind": {
+                    "speed": 2.35,
+                    "deg": 297,
+                    "gust": 2.7
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-15 09:00:00"
+            },
+            {
+                "dt": 1657886400,
+                "main": {
+                    "temp": 24.63,
+                    "feels_like": 23.96,
+                    "temp_min": 24.63,
+                    "temp_max": 24.63,
+                    "pressure": 1023,
+                    "sea_level": 1023,
+                    "grnd_level": 1020,
+                    "humidity": 31,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 39
+                },
+                "wind": {
+                    "speed": 3.1,
+                    "deg": 269,
+                    "gust": 4.89
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-15 12:00:00"
+            },
+            {
+                "dt": 1657897200,
+                "main": {
+                    "temp": 26.2,
+                    "feels_like": 26.2,
+                    "temp_min": 26.2,
+                    "temp_max": 26.2,
+                    "pressure": 1022,
+                    "sea_level": 1022,
+                    "grnd_level": 1018,
+                    "humidity": 33,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 48
+                },
+                "wind": {
+                    "speed": 4.58,
+                    "deg": 273,
+                    "gust": 6.63
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-15 15:00:00"
+            },
+            {
+                "dt": 1657908000,
+                "main": {
+                    "temp": 25.57,
+                    "feels_like": 25.04,
+                    "temp_min": 25.57,
+                    "temp_max": 25.57,
+                    "pressure": 1021,
+                    "sea_level": 1021,
+                    "grnd_level": 1018,
+                    "humidity": 33,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 52
+                },
+                "wind": {
+                    "speed": 4.08,
+                    "deg": 310,
+                    "gust": 6.8
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-15 18:00:00"
+            },
+            {
+                "dt": 1657918800,
+                "main": {
+                    "temp": 17.53,
+                    "feels_like": 16.8,
+                    "temp_min": 17.53,
+                    "temp_max": 17.53,
+                    "pressure": 1023,
+                    "sea_level": 1023,
+                    "grnd_level": 1020,
+                    "humidity": 56,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 801,
+                        "main": "Clouds",
+                        "description": "few clouds",
+                        "icon": "02n"
+                    }
+                ],
+                "clouds": {
+                    "all": 11
+                },
+                "wind": {
+                    "speed": 2.93,
+                    "deg": 353,
+                    "gust": 3.71
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-15 21:00:00"
+            },
+            {
+                "dt": 1657929600,
+                "main": {
+                    "temp": 15,
+                    "feels_like": 14.36,
+                    "temp_min": 15,
+                    "temp_max": 15,
+                    "pressure": 1024,
+                    "sea_level": 1024,
+                    "grnd_level": 1020,
+                    "humidity": 69,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 53
+                },
+                "wind": {
+                    "speed": 2.76,
+                    "deg": 357,
+                    "gust": 3.58
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-16 00:00:00"
+            },
+            {
+                "dt": 1657940400,
+                "main": {
+                    "temp": 12.5,
+                    "feels_like": 12,
+                    "temp_min": 12.5,
+                    "temp_max": 12.5,
+                    "pressure": 1024,
+                    "sea_level": 1024,
+                    "grnd_level": 1021,
+                    "humidity": 84,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 95
+                },
+                "wind": {
+                    "speed": 2.86,
+                    "deg": 356,
+                    "gust": 4.35
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-16 03:00:00"
+            },
+            {
+                "dt": 1657951200,
+                "main": {
+                    "temp": 15.04,
+                    "feels_like": 14.45,
+                    "temp_min": 15.04,
+                    "temp_max": 15.04,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 71,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 95
+                },
+                "wind": {
+                    "speed": 2.37,
+                    "deg": 355,
+                    "gust": 4.44
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-16 06:00:00"
+            },
+            {
+                "dt": 1657962000,
+                "main": {
+                    "temp": 21.37,
+                    "feels_like": 20.63,
+                    "temp_min": 21.37,
+                    "temp_max": 21.37,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 41,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 74
+                },
+                "wind": {
+                    "speed": 3.21,
+                    "deg": 7,
+                    "gust": 3.62
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-16 09:00:00"
+            },
+            {
+                "dt": 1657972800,
+                "main": {
+                    "temp": 26.1,
+                    "feels_like": 26.1,
+                    "temp_min": 26.1,
+                    "temp_max": 26.1,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 29,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 44
+                },
+                "wind": {
+                    "speed": 2.61,
+                    "deg": 11,
+                    "gust": 3.22
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-16 12:00:00"
+            },
+            {
+                "dt": 1657983600,
+                "main": {
+                    "temp": 26.83,
+                    "feels_like": 26.31,
+                    "temp_min": 26.83,
+                    "temp_max": 26.83,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 30,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 37
+                },
+                "wind": {
+                    "speed": 1.67,
+                    "deg": 147,
+                    "gust": 3.16
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-16 15:00:00"
+            },
+            {
+                "dt": 1657994400,
+                "main": {
+                    "temp": 21.12,
+                    "feels_like": 20.65,
+                    "temp_min": 21.12,
+                    "temp_max": 21.12,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1022,
+                    "humidity": 52,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 40
+                },
+                "wind": {
+                    "speed": 4.21,
+                    "deg": 170,
+                    "gust": 4.7
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-16 18:00:00"
+            },
+            {
+                "dt": 1658005200,
+                "main": {
+                    "temp": 15.27,
+                    "feels_like": 14.86,
+                    "temp_min": 15.27,
+                    "temp_max": 15.27,
+                    "pressure": 1027,
+                    "sea_level": 1027,
+                    "grnd_level": 1023,
+                    "humidity": 77,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 801,
+                        "main": "Clouds",
+                        "description": "few clouds",
+                        "icon": "02n"
+                    }
+                ],
+                "clouds": {
+                    "all": 19
+                },
+                "wind": {
+                    "speed": 1.57,
+                    "deg": 156,
+                    "gust": 1.64
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-16 21:00:00"
+            },
+            {
+                "dt": 1658016000,
+                "main": {
+                    "temp": 14.1,
+                    "feels_like": 13.39,
+                    "temp_min": 14.1,
+                    "temp_max": 14.1,
+                    "pressure": 1027,
+                    "sea_level": 1027,
+                    "grnd_level": 1024,
+                    "humidity": 70,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03n"
+                    }
+                ],
+                "clouds": {
+                    "all": 27
+                },
+                "wind": {
+                    "speed": 1.14,
+                    "deg": 91,
+                    "gust": 1.21
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-17 00:00:00"
+            },
+            {
+                "dt": 1658026800,
+                "main": {
+                    "temp": 13.49,
+                    "feels_like": 12.64,
+                    "temp_min": 13.49,
+                    "temp_max": 13.49,
+                    "pressure": 1027,
+                    "sea_level": 1027,
+                    "grnd_level": 1024,
+                    "humidity": 67,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 58
+                },
+                "wind": {
+                    "speed": 1.04,
+                    "deg": 72,
+                    "gust": 1.1
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-17 03:00:00"
+            },
+            {
+                "dt": 1658037600,
+                "main": {
+                    "temp": 17.75,
+                    "feels_like": 16.94,
+                    "temp_min": 17.75,
+                    "temp_max": 17.75,
+                    "pressure": 1028,
+                    "sea_level": 1028,
+                    "grnd_level": 1025,
+                    "humidity": 52,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 34
+                },
+                "wind": {
+                    "speed": 1.08,
+                    "deg": 104,
+                    "gust": 1.13
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-17 06:00:00"
+            },
+            {
+                "dt": 1658048400,
+                "main": {
+                    "temp": 24.77,
+                    "feels_like": 24.22,
+                    "temp_min": 24.77,
+                    "temp_max": 24.77,
+                    "pressure": 1027,
+                    "sea_level": 1027,
+                    "grnd_level": 1024,
+                    "humidity": 35,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 800,
+                        "main": "Clear",
+                        "description": "clear sky",
+                        "icon": "01d"
+                    }
+                ],
+                "clouds": {
+                    "all": 6
+                },
+                "wind": {
+                    "speed": 2.49,
+                    "deg": 147,
+                    "gust": 2.29
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-17 09:00:00"
+            },
+            {
+                "dt": 1658059200,
+                "main": {
+                    "temp": 27.74,
+                    "feels_like": 26.91,
+                    "temp_min": 27.74,
+                    "temp_max": 27.74,
+                    "pressure": 1027,
+                    "sea_level": 1027,
+                    "grnd_level": 1024,
+                    "humidity": 30,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 801,
+                        "main": "Clouds",
+                        "description": "few clouds",
+                        "icon": "02d"
+                    }
+                ],
+                "clouds": {
+                    "all": 23
+                },
+                "wind": {
+                    "speed": 3.99,
+                    "deg": 181,
+                    "gust": 2.83
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-17 12:00:00"
+            },
+            {
+                "dt": 1658070000,
+                "main": {
+                    "temp": 28.08,
+                    "feels_like": 27.15,
+                    "temp_min": 28.08,
+                    "temp_max": 28.08,
+                    "pressure": 1026,
+                    "sea_level": 1026,
+                    "grnd_level": 1023,
+                    "humidity": 30,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 802,
+                        "main": "Clouds",
+                        "description": "scattered clouds",
+                        "icon": "03d"
+                    }
+                ],
+                "clouds": {
+                    "all": 45
+                },
+                "wind": {
+                    "speed": 3.89,
+                    "deg": 175,
+                    "gust": 2.4
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-17 15:00:00"
+            },
+            {
+                "dt": 1658080800,
+                "main": {
+                    "temp": 26.32,
+                    "feels_like": 26.32,
+                    "temp_min": 26.32,
+                    "temp_max": 26.32,
+                    "pressure": 1026,
+                    "sea_level": 1026,
+                    "grnd_level": 1022,
+                    "humidity": 33,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 67
+                },
+                "wind": {
+                    "speed": 3.84,
+                    "deg": 169,
+                    "gust": 4.55
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-17 18:00:00"
+            },
+            {
+                "dt": 1658091600,
+                "main": {
+                    "temp": 19.6,
+                    "feels_like": 18.9,
+                    "temp_min": 19.6,
+                    "temp_max": 19.6,
+                    "pressure": 1026,
+                    "sea_level": 1026,
+                    "grnd_level": 1023,
+                    "humidity": 49,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 73
+                },
+                "wind": {
+                    "speed": 1.6,
+                    "deg": 113,
+                    "gust": 1.72
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-17 21:00:00"
+            },
+            {
+                "dt": 1658102400,
+                "main": {
+                    "temp": 17.97,
+                    "feels_like": 17.21,
+                    "temp_min": 17.97,
+                    "temp_max": 17.97,
+                    "pressure": 1026,
+                    "sea_level": 1026,
+                    "grnd_level": 1022,
+                    "humidity": 53,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 74
+                },
+                "wind": {
+                    "speed": 2.01,
+                    "deg": 109,
+                    "gust": 2.14
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-18 00:00:00"
+            },
+            {
+                "dt": 1658113200,
+                "main": {
+                    "temp": 16.89,
+                    "feels_like": 16.25,
+                    "temp_min": 16.89,
+                    "temp_max": 16.89,
+                    "pressure": 1025,
+                    "sea_level": 1025,
+                    "grnd_level": 1021,
+                    "humidity": 62,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 803,
+                        "main": "Clouds",
+                        "description": "broken clouds",
+                        "icon": "04n"
+                    }
+                ],
+                "clouds": {
+                    "all": 72
+                },
+                "wind": {
+                    "speed": 1.9,
+                    "deg": 132,
+                    "gust": 2.02
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "n"
+                },
+                "dt_txt": "2022-07-18 03:00:00"
+            },
+            {
+                "dt": 1658124000,
+                "main": {
+                    "temp": 20.79,
+                    "feels_like": 20.28,
+                    "temp_min": 20.79,
+                    "temp_max": 20.79,
+                    "pressure": 1024,
+                    "sea_level": 1024,
+                    "grnd_level": 1021,
+                    "humidity": 52,
+                    "temp_kf": 0
+                },
+                "weather": [
+                    {
+                        "id": 804,
+                        "main": "Clouds",
+                        "description": "overcast clouds",
+                        "icon": "04d"
+                    }
+                ],
+                "clouds": {
+                    "all": 85
+                },
+                "wind": {
+                    "speed": 2.27,
+                    "deg": 137,
+                    "gust": 5.96
+                },
+                "visibility": 10000,
+                "pop": 0,
+                "sys": {
+                    "pod": "d"
+                },
+                "dt_txt": "2022-07-18 06:00:00"
+            }
+        ],
+        "city": {
+            "id": 2655662,
+            "name": "Billingshurst",
+            "coord": {
+                "lat": 51.0192,
+                "lon": -0.4541
+            },
+            "country": "GB",
+            "population": 5587,
+            "timezone": 3600,
+            "sunrise": 1657684921,
+            "sunset": 1657743159
+        }
+    },
+    "FAILURE": {
+        "404": {
+            "cod": 404,
+            "message": "city not found"
+        },
+        "401": {
+            "cod": 401,
+            "message": "invalid API key"
+        },
+        "429": {
+            "cod": 429,
+            "message": "too many requests"
+        }
+    }
+}

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -3,6 +3,7 @@ from platform import system
 
 import pytest
 from ace.intents import run_intent
+from freezegun import freeze_time
 from pytest import mark
 
 
@@ -244,6 +245,153 @@ class TestCurrentWeatherIntent:
             lambda *args, success=True: mock_weather_response_success,
         )
         response, exit_script = run_intent("current_weather", text)
+
+        assert response == expected
+        assert exit_script is False
+
+
+@freeze_time("13-07-2022 08:00:00")
+class TestTomorrowWeatherIntent:
+    environment = {"ACE_WEATHER_KEY": "123456789", "ACE_HOME": "London"}
+    mock_weather_file = "tests/data/weather/tomorrow_weather.json"
+
+    @pytest.fixture
+    def mock_weather_response_success(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["SUCCESS"]
+
+    @pytest.fixture
+    def mock_weather_response_failure_404(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["FAILURE"]["404"]
+
+    @pytest.fixture
+    def mock_weather_response_failure_401(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["FAILURE"]["401"]
+
+    @pytest.fixture
+    def mock_weather_response_failure_429(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["FAILURE"]["429"]
+
+    def test_tomorrow_weather_response_incorrect_city(
+        self, monkeypatch, mock_weather_response_failure_404
+    ):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args: mock_weather_response_failure_404,
+        )
+
+        response, exit_script = run_intent(
+            "tomorrow_weather", "tomorrow weather in London"
+        )
+
+        assert (
+            response == "Couldn't find that location. Check the spelling and try again."
+        )
+        assert exit_script is False
+
+    def test_tomorrow_weather_response_incorrect_key(
+        self, monkeypatch, mock_weather_response_failure_401
+    ):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args: mock_weather_response_failure_401,
+        )
+
+        response, exit_script = run_intent(
+            "tomorrow_weather", "tomorrow weather in London"
+        )
+
+        assert (
+            response
+            == "The configured weather API key is invalid. Please check the 'ACE_WEATHER_KEY' environment variable."
+        )
+        assert exit_script is False
+
+    def test_tomorrow_weather_response_too_many_requests(
+        self, monkeypatch, mock_weather_response_failure_429
+    ):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args, success=False: mock_weather_response_failure_429,
+        )
+        response, exit_script = run_intent(
+            "tomorrow_weather", "tomorrow weather in London"
+        )
+
+        assert (
+            response
+            == "The configured weather API key has been used too many times. Please wait and try again."
+        )
+        assert exit_script is False
+
+    def test_tomorrow_weather_response_unknown_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args: None,
+        )
+        response, exit_script = run_intent(
+            "tomorrow_weather", "tomorrow weather in London"
+        )
+
+        assert (
+            response
+            == "Sorry, I couldn't get the weather for you. Check your connection and try again."
+        )
+        assert exit_script is False
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            (
+                "Tomorrow weather",
+                "The weather tomorrow in London will be 19.99\N{DEGREE SIGN}C and scattered clouds.",
+            ),
+            (
+                "tomorrow weather conditions",
+                "The weather tomorrow in London will be 19.99\N{DEGREE SIGN}C and scattered clouds.",
+            ),
+            (
+                "weather tomorrow in London",
+                "The weather tomorrow in London will be 19.99\N{DEGREE SIGN}C and scattered clouds.",
+            ),
+            (
+                "Get weather tomorrow in Billingshurst",
+                "The weather tomorrow in Billingshurst will be 19.99\N{DEGREE SIGN}C and scattered clouds.",
+            ),
+            (
+                "get tomorrow weather in Paris",
+                "The weather tomorrow in Paris will be 19.99\N{DEGREE SIGN}C and scattered clouds.",
+            ),
+            (
+                "Tomorrow weather conditions",
+                "The weather tomorrow in London will be 19.99\N{DEGREE SIGN}C and scattered clouds.",
+            ),
+            (
+                "Tomorrow's weather",
+                "The weather tomorrow in London will be 19.99\N{DEGREE SIGN}C and scattered clouds.",
+            ),
+        ],
+    )
+    def test_tomorrow_weather_api_response(
+        self,
+        monkeypatch,
+        text,
+        expected,
+        mock_weather_response_success,
+    ):
+        monkeypatch.setattr(
+            "ace.apis.os.environ",
+            self.environment,
+        )
+
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args, success=True: mock_weather_response_success,
+        )
+        response, exit_script = run_intent("tomorrow_weather", text)
 
         assert response == expected
         assert exit_script is False

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -1,6 +1,9 @@
+import json
 from platform import system
-from pytest import mark
+
+import pytest
 from ace.intents import run_intent
+from pytest import mark
 
 
 def test_unknown_intent():
@@ -97,4 +100,150 @@ class TestCloseAppIntent:
         response, exit_script = run_intent("close_app", "close UnknownApp")
 
         assert response == "Sorry, I can't close 'UnknownApp'. Is it running?"
+        assert exit_script is False
+
+
+class TestCurrentWeatherIntent:
+    environment = {"ACE_WEATHER_KEY": "123456789", "ACE_HOME": "London"}
+    mock_weather_file = "tests/data/weather/current_weather.json"
+
+    @pytest.fixture
+    def mock_weather_response_success(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["SUCCESS"]
+
+    @pytest.fixture
+    def mock_weather_response_failure_404(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["FAILURE"]["404"]
+
+    @pytest.fixture
+    def mock_weather_response_failure_401(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["FAILURE"]["401"]
+
+    @pytest.fixture
+    def mock_weather_response_failure_429(self):
+        with open(self.mock_weather_file) as f:
+            return json.load(f)["FAILURE"]["429"]
+
+    @staticmethod
+    def test_current_weather_response_incorrect_city(
+        monkeypatch, mock_weather_response_failure_404
+    ):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args: mock_weather_response_failure_404,
+        )
+
+        response, exit_script = run_intent(
+            "current_weather", "current weather in London"
+        )
+
+        assert (
+            response == "Couldn't find that location. Check the spelling and try again."
+        )
+        assert exit_script is False
+
+    @staticmethod
+    def test_current_weather_response_incorrect_key(
+        monkeypatch, mock_weather_response_failure_401
+    ):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args: mock_weather_response_failure_401,
+        )
+
+        response, exit_script = run_intent(
+            "current_weather", "current weather in London"
+        )
+
+        assert (
+            response
+            == "The configured weather API key is invalid. Please check the 'ACE_WEATHER_KEY' environment variable."
+        )
+        assert exit_script is False
+
+    @staticmethod
+    def test_current_weather_response_too_many_requests(
+        monkeypatch, mock_weather_response_failure_429
+    ):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args, success=False: mock_weather_response_failure_429,
+        )
+        response, exit_script = run_intent(
+            "current_weather", "current weather in London"
+        )
+
+        assert (
+            response
+            == "The configured weather API key has been used too many times. Please wait and try again."
+        )
+        assert exit_script is False
+
+    @staticmethod
+    def test_current_weather_response_unknown_error(monkeypatch):
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args: None,
+        )
+        response, exit_script = run_intent(
+            "current_weather", "current weather in London"
+        )
+
+        assert (
+            response
+            == "Sorry, I couldn't get the weather for you. Check your connection and try again."
+        )
+        assert exit_script is False
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            (
+                "Current weather",
+                "The weather in London is 14.19\N{DEGREE SIGN}C and few clouds.",
+            ),
+            (
+                "current weather conditions",
+                "The weather in London is 14.19\N{DEGREE SIGN}C and few clouds.",
+            ),
+            (
+                "weather in London",
+                "The weather in London is 14.19\N{DEGREE SIGN}C and few clouds.",
+            ),
+            (
+                "Get weather in Billingshurst",
+                "The weather in Billingshurst is 14.19\N{DEGREE SIGN}C and few clouds.",
+            ),
+            (
+                "get current weather in Paris",
+                "The weather in Paris is 14.19\N{DEGREE SIGN}C and few clouds.",
+            ),
+            (
+                "Current weather conditions",
+                "The weather in London is 14.19\N{DEGREE SIGN}C and few clouds.",
+            ),
+        ],
+    )
+    def test_current_weather_api_response(
+        self,
+        monkeypatch,
+        text,
+        expected,
+        mock_weather_response_success,
+    ):
+        monkeypatch.setattr(
+            "ace.apis.os.environ",
+            self.environment,
+        )
+
+        monkeypatch.setattr(
+            "ace.intents.WeatherAPI._get_response",
+            lambda *args, success=True: mock_weather_response_success,
+        )
+        response, exit_script = run_intent("current_weather", text)
+
+        assert response == expected
         assert exit_script is False

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -64,3 +64,16 @@ class TestIntentModel:
     )
     def test_predict_close_app(self, text, expected):
         assert self.model.predict(text) == expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Current weather", "current_weather"),
+            ("current weather conditions", "current_weather"),
+            ("weather in London", "current_weather"),
+            ("Get weather in Billingshurst", "current_weather"),
+            ("get current weather in Paris", "current_weather"),
+        ],
+    )
+    def test_predict_current_weather(self, text, expected):
+        assert self.model.predict(text) == expected

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -77,3 +77,17 @@ class TestIntentModel:
     )
     def test_predict_current_weather(self, text, expected):
         assert self.model.predict(text) == expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Tomorrow's weather", "tomorrow_weather"),
+            ("tomorrow's weather conditions", "tomorrow_weather"),
+            ("weather tomorrow in London", "tomorrow_weather"),
+            ("Get weather tomorrow in Billingshurst", "tomorrow_weather"),
+            ("what will tomorrow's weather be", "tomorrow_weather"),
+            ("tomorrow weather in Paris", "tomorrow_weather"),
+        ],
+    )
+    def test_predict_tomorrow_weather(self, text, expected):
+        assert self.model.predict(text) == expected


### PR DESCRIPTION
### Changes
- Add current_weather intent to IntentModel.predict method in net.py
- Add current_weather intent functionality
- Add requests using poetry
- Add current_weather intent to README.md
- Add tomorrow_weather intent to IntentModel.predict method in net.py
- Add freezegun module using poetry
- Add tomorrow_weather intent functionality
- Add tomorrow_weather intent to README.md
- Add cachetools using poetry 
- Remove unused pprint module in apis.py
- Improve speed of the WeatherAPI class