### PR TITLE
Remove deprecated os from continuous_integration.yaml

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10"]
         poetry-version: [1.1.13]
-        os: [windows-2019, windows-latest, ubuntu-18.04, ubuntu-latest]
+        os: [windows-2019, windows-latest, ubuntu-20.04, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
### Changes
- Remove deprecated os from continuous_integration.yaml